### PR TITLE
Fix travis buids

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
-sudo: false
 language: python
+os: linux
+dist: "bionic"
 services:
   - redis
 python:
   - "3.6"
 install:
+  - pip install -r requirements.txt
   - pip install -e .
-  - pip install --upgrade pytest pytest-cov coveralls pytest-mock flake8 flake8-isort
+  - pip install pytest-cov coveralls flake8 flake8-isort
 script:
   - pytest --cov redis_tasks --run-slow
   - flake8 .

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 install:
   - pip install -r requirements.txt
   - pip install -e .
-  - pip install pytest-cov coveralls flake8 flake8-isort
+  - pip install coveralls flake8 flake8-isort
 script:
   - pytest --cov redis_tasks --run-slow
   - flake8 .

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 install:
   - pip install -r requirements.txt
   - pip install -e .
-  - pip install coveralls flake8 flake8-isort
+  - pip install coveralls
 script:
   - pytest --cov redis_tasks --run-slow
   - flake8 .

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ services:
   - redis
 python:
   - "3.6"
+  - "3.7"
+  - "3.8"
 install:
   - pip install -r requirements.txt
   - pip install -e .

--- a/redis_tasks/contrib/django/__init__.py
+++ b/redis_tasks/contrib/django/__init__.py
@@ -3,8 +3,8 @@ from itertools import chain
 from django.apps import AppConfig
 from django.conf import settings as django_settings
 
-from ...conf import settings
 from ... import defaults
+from ...conf import settings
 
 SETTINGS_PREFIX = 'RT_'
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,9 @@
 redis
 click
-pytest
-pytest-mock
 pip-tools
 croniter
 pytz
+
+pytest
+pytest-mock
+pytest-cov

--- a/requirements.in
+++ b/requirements.in
@@ -7,3 +7,6 @@ pytz
 pytest
 pytest-mock
 pytest-cov
+
+flake8
+flake8-isort

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,15 +6,22 @@
 #
 attrs==18.1.0             # via pytest
 click==6.7
+coverage==5.0.4           # via pytest-cov
 croniter==0.3.22
 first==2.0.1              # via pip-tools
+importlib-metadata==1.5.0  # via pluggy, pytest
 more-itertools==4.1.0     # via pytest
+packaging==20.3           # via pytest
 pip-tools==2.0.2
-pluggy==0.6.0             # via pytest
+pluggy==0.13.1            # via pytest
 py==1.5.3                 # via pytest
+pyparsing==2.4.6          # via packaging
+pytest-cov==2.8.1
 pytest-mock==1.10.0
-pytest==3.5.1
+pytest==5.4.1
 python-dateutil==2.7.3    # via croniter
 pytz==2018.4
 redis==2.10.6
-six==1.11.0               # via more-itertools, pip-tools, pytest, python-dateutil
+six==1.11.0               # via more-itertools, packaging, pip-tools, python-dateutil
+wcwidth==0.1.9            # via pytest
+zipp==3.1.0               # via importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,13 +8,20 @@ attrs==18.1.0             # via pytest
 click==6.7
 coverage==5.0.4           # via pytest-cov
 croniter==0.3.22
+entrypoints==0.3          # via flake8
 first==2.0.1              # via pip-tools
+flake8-isort==2.9.0
+flake8==3.7.9
 importlib-metadata==1.5.0  # via pluggy, pytest
+isort[pyproject]==4.3.21  # via flake8-isort
+mccabe==0.6.1             # via flake8
 more-itertools==4.1.0     # via pytest
 packaging==20.3           # via pytest
 pip-tools==2.0.2
 pluggy==0.13.1            # via pytest
 py==1.5.3                 # via pytest
+pycodestyle==2.5.0        # via flake8
+pyflakes==2.1.1           # via flake8
 pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1
 pytest-mock==1.10.0
@@ -23,5 +30,7 @@ python-dateutil==2.7.3    # via croniter
 pytz==2018.4
 redis==2.10.6
 six==1.11.0               # via more-itertools, packaging, pip-tools, python-dateutil
+testfixtures==6.14.0      # via flake8-isort
+toml==0.10.0              # via isort
 wcwidth==0.1.9            # via pytest
 zipp==3.1.0               # via importlib-metadata

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ def pytest_addoption(parser):
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_setup(item):
-    if not pytest.config.getoption("--run-slow"):
+    if not item.config.getoption("--run-slow"):
         if item.keywords.get('slow'):
             pytest.skip("Test is marked as slow")
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,3 +4,5 @@ max-line-length=100
 [pytest]
 testpaths = tests
 log_level = DEBUG
+markers =
+    slow: Mark the test as slow, so it will only run with --run-slow


### PR DESCRIPTION
Unpinned versions of packages installed in Travis lead to builds as the versions had breaking changes compared to the versions used in development