### PR TITLE
Remove kaloyanm from dependabot reviewers

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -8,7 +8,6 @@ update_configs:
     default_reviewers:
       - "i-trofimtschuk"
       - "vasilty"
-      - "kaloyanm"
       - "djangsters/backend"
     update_schedule: "weekly"
     allowed_updates:


### PR DESCRIPTION
otherwise we get this error

Dependabot tried to add @i-trofimtschuk, @vasilty, @kaloyanm and @djangsters/backend as reviewers to this PR, but received the following error from GitHub:

POST https://api.github.com/repos/djangsters/redis-tasks/pulls/60/requested_reviewers: 422 - Reviews may only be requested from collaborators. One or more of the users or teams you specified is not a collaborator of the djangsters/redis-tasks repository. // See: https://developer.github.com/v3/pulls/review_requests/#create-a-review-request
