### PR TITLE
bump version by hand: isort 5.9.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ importlib-metadata==4.6.1
     #   pytest
 iniconfig==1.1.1
     # via pytest
-isort==4.3.21
+isort==5.9.3
     # via flake8-isort
 mccabe==0.6.1
     # via flake8

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ class ModifiableSettings:
 @pytest.fixture()
 def settings():
     from redis_tasks import conf
+
     # ensure the settings are initialized
     conf.settings.DEFAULT_TASK_TIMEOUT
     original_dict = conf.settings.__dict__

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,8 +7,9 @@ from tests.utils import QueueFactory, WorkerFactory
 
 @pytest.fixture
 def cli_run():
-    from redis_tasks.cli import main as cli_main
     from click.testing import CliRunner
+
+    from redis_tasks.cli import main as cli_main
     runner = CliRunner()
 
     def run(*args):


### PR DESCRIPTION
The PR from dependabot which updates to the new isort fails in CI with py36

This PR created on my local machine works with py36.

Let's give it a try.